### PR TITLE
0.9.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,26 @@
 Change history
 ==============
 
+0.9.5
+=====
+
+*December 14, 2017*
+
+* Fixed issue where the default value for XSD elements were seen as "provided"
+  by the request. This lead to incorrect lookups.
+* Restored validation of the incoming requests again. This was accidentally
+  removed to work with the StUF testplatform in 0.9.4. Note that with the
+  introduction of the KING reference WSDL, this validation is much more
+  strict.
+* Altered the ``voegZaakdocumentToe`` service to create a document in a single
+  action instead of 2 (create document, add content to document). This
+  deviates from the specification but prevents documents starting at version
+  1.1. Documents in the DMS now start at version 1.0.
+* Added the "stuurgegevens/zender" information to a custom DMS property. This
+  property can be configured with ``CMIS_SENDER_PROPERTY`` and should be a
+  ``string``, or ``None`` if no sender property is present.
+
+
 0.9.4
 =====
 

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -121,6 +121,12 @@ uit de basis configuratie.
     Boomstructuur als volgt: ``Sites`` > ``archief`` > ``documentLibrary`` >
     ``<Zaak type>`` > ``<year>`` > ``<month>`` > ``<day>`` > ``<Zaak ID>``
 
+* ``CMIS_SENDER_PROPERTY`` (standaard: ``None``)
+
+  Zet de "stuurgegevens/zender" informatie in dit DMS veld. Laat ``None``
+  indien er geen veld hiervoor in het DMS aanwezig is. Het DMS veld wordt
+  gevuld met het meest specifieke zender veld in het verzoek aan het ZM.
+
 
 Commando's
 ==========

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Zaakmagazijn
 ============
 
-:Version: 0.9.4
+:Version: 0.9.5
 :Source: https://github.com/maykinmedia/zaakregistratiecomponent
 :Keywords: zaaksysteem, zakenmagazijn, zds, zaakservices, documentservices, soap, zds
 
@@ -27,7 +27,7 @@ Vanuit dit systeem kunnen zowel interne als externe stakeholders inzicht
 krijgen in de status, de bij de uitvoering betrokken partijen, de doorlooptijd
 van afhandeling van zaken en daarmee ook in de kwaliteit van uitvoer van het
 proces. Opslag van zaakgegevens gebeurt conform het RGBZ (2.0), het RSGB (2.0)
-enhet ImZTC (2.1).
+en het ImZTC (2.1).
 
 Het Zaakmagazijn ondersteunt de volgende functionaliteiten:
 

--- a/src/zaakmagazijn/api/applications.py
+++ b/src/zaakmagazijn/api/applications.py
@@ -181,6 +181,8 @@ class AsyncApplication(Application):
     FAULT_CLASS = SpyneAsyncStUFFault
 
 
+# Validator `None` means to validate against the KING reference WSDL.
+# See: zaakmagazijn.api.stuf.protocols.StUFSynchronous.validate_document
 beantwoordvraag_app = Application(
     [GeefBesluitDetails, GeefZaakstatus, GeefLijstBesluiten, GeefZaakdetails,
      GeefLijstZaakdocumenten, GeefZaakdocumentLezen],

--- a/src/zaakmagazijn/api/stuf/constants.py
+++ b/src/zaakmagazijn/api/stuf/constants.py
@@ -3,6 +3,7 @@ ZKN_XML_NS = 'http://www.egem.nl/StUF/sector/zkn/0310'
 BG_XML_NS = 'http://www.egem.nl/StUF/sector/bg/0310'
 ZDS_XML_NS = 'http://www.stufstandaarden.nl/koppelvlak/zds0120'
 XMIME_XML_NS = 'http://www.w3.org/2005/05/xmlmime'
+GML_XML_NS = 'http://www.opengis.net/gml'
 
 NS_MAP = {
     'stuf': STUF_XML_NS,

--- a/src/zaakmagazijn/api/stuf/utils.py
+++ b/src/zaakmagazijn/api/stuf/utils.py
@@ -97,9 +97,12 @@ def django_field_to_spyne_model(django_field, default=None, nullable=None, min_o
     spyne_model = DEFAULT_FIELD_MAP[field_type]
 
     kwargs = {}
-    if default is None and django_field.has_default():
-        kwargs['default'] = django_field.get_default()
-    elif default is not None:
+    # NOTE: Taiga 397 reported issues with defaults. The default is
+    # interpreted as "provided" by the request, which is not true.
+    #
+    # if default is None and django_field.has_default():
+    #     kwargs['default'] = django_field.get_default()
+    if default is not None:
         kwargs['default'] = default
 
     if nullable is None and django_field.null:

--- a/src/zaakmagazijn/api/tests/files/maykin_creeerZaak/creeerZaak_ZakLk01_taiga397.xml
+++ b/src/zaakmagazijn/api/tests/files/maykin_creeerZaak/creeerZaak_ZakLk01_taiga397.xml
@@ -1,0 +1,74 @@
+<zds:creeerZaak_ZakLk01 xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:zds="http://www.stufstandaarden.nl/koppelvlak/zds0120" xmlns:ns="http://www.egem.nl/StUF/sector/zkn/0310" xmlns:stuf="http://www.egem.nl/StUF/StUF0301" xmlns:ns1="http://www.egem.nl/StUF/sector/bg/0310">
+    <ns:stuurgegevens>
+        <stuf:berichtcode>Lk01</stuf:berichtcode>
+        <stuf:zender>
+            <stuf:organisatie>1</stuf:organisatie>
+            <stuf:applicatie>SoapUI</stuf:applicatie>
+            <stuf:administratie>test</stuf:administratie>
+            <stuf:gebruiker>David</stuf:gebruiker>
+        </stuf:zender>
+        <stuf:ontvanger>
+            <stuf:organisatie>0392</stuf:organisatie>
+            <stuf:applicatie>SoapUI</stuf:applicatie>
+            <stuf:administratie>test</stuf:administratie>
+            <stuf:gebruiker>David</stuf:gebruiker>
+        </stuf:ontvanger>
+        <stuf:referentienummer>1</stuf:referentienummer>
+        <stuf:tijdstipBericht>201711291505500</stuf:tijdstipBericht>
+        <stuf:entiteittype>ZAK</stuf:entiteittype>
+    </ns:stuurgegevens>
+    <ns:parameters>
+        <stuf:mutatiesoort>T</stuf:mutatiesoort>
+        <stuf:indicatorOvername>V</stuf:indicatorOvername>
+    </ns:parameters>
+    <ns:object stuf:entiteittype="ZAK" stuf:verwerkingssoort="T">
+        <ns:identificatie>2017-0000561</ns:identificatie>
+        <ns:omschrijving>Testmelding</ns:omschrijving>
+        <ns:toelichting>Dit is de inhoud van de melding.</ns:toelichting>
+
+        <ns:anderZaakObject>
+            <!--Optional:-->
+            <ns:omschrijving>contactpersoon</ns:omschrijving>
+            <!--Optional:-->
+            <ns:aanduiding>contactpersoon</ns:aanduiding>
+            <!--Optional:-->
+            <ns:registratie>idvanpersoon</ns:registratie>
+        </ns:anderZaakObject>
+
+        <ns:startdatum  stuf:exact="true" stuf:indOnvolledigeDatum="V">20171129</ns:startdatum>
+        <ns:registratiedatum  stuf:exact="true" stuf:indOnvolledigeDatum="V">20171129</ns:registratiedatum>
+        <ns:einddatumGepland>171215</ns:einddatumGepland>
+        <ns:archiefnominatie>J</ns:archiefnominatie>
+        <ns:zaakniveau>1</ns:zaakniveau>
+        <ns:deelzakenIndicatie>N</ns:deelzakenIndicatie>
+        <ns:isVan stuf:entiteittype="ZAKZKT" stuf:verwerkingssoort="T" >
+            <ns:gerelateerde stuf:entiteittype="ZKT" stuf:verwerkingssoort="I" >
+                <ns:code>1</ns:code>
+                <!-- If defaults are used for Spyne fields, adding this
+                     (overriding the default) works:
+
+                <ns:ingangsdatumObject>20170901</ns:ingangsdatumObject>
+                -->
+            </ns:gerelateerde>
+        </ns:isVan>
+
+        <ns:heeftAlsInitiator stuf:entiteittype="ZAKBTRINI" stuf:verwerkingssoort="T">
+            <ns:gerelateerde>
+                <ns:organisatorischeEenheid stuf:entiteittype="OEH" stuf:verwerkingssoort="I">
+                    <ns:identificatie>DVV/KCC</ns:identificatie>
+                </ns:organisatorischeEenheid>
+
+            </ns:gerelateerde>
+        </ns:heeftAlsInitiator>
+
+        <ns:heeftAlsVerantwoordelijke stuf:entiteittype="ZAKBTRVRA" stuf:verwerkingssoort="T" >
+            <ns:gerelateerde>
+                <ns:organisatorischeEenheid stuf:entiteittype="OEH" stuf:verwerkingssoort="I">
+                    <ns:identificatie>DVV/KCC</ns:identificatie>
+                </ns:organisatorischeEenheid>
+            </ns:gerelateerde>
+        </ns:heeftAlsVerantwoordelijke>
+
+
+    </ns:object>
+</zds:creeerZaak_ZakLk01>

--- a/src/zaakmagazijn/api/tests/test_creeer_zaak.py
+++ b/src/zaakmagazijn/api/tests/test_creeer_zaak.py
@@ -646,6 +646,9 @@ class creeerZaak_ZakLk01RegressionTests(BaseTestPlatformTests):
 
         self.assertEquals(response.status_code, 200, response.content)
 
+        self.assertEqual(Zaak.objects.all().count(), 1)
+        self.assertEqual(Zaak.objects.filter(zaakidentificatie='039288072b1c-54f4-485c-8e83-095621e6jkl6').count(), 1)
+
     def test_naam_matching_query_does_not_exist(self):
         """
         See: https://taiga.maykinmedia.nl/project/haarlem-zaakmagazijn/issue/281
@@ -663,3 +666,37 @@ class creeerZaak_ZakLk01RegressionTests(BaseTestPlatformTests):
         response = self._do_request(self.porttype, vraag)
 
         self.assertEquals(response.status_code, 200, response.content)
+
+        self.assertEqual(Zaak.objects.all().count(), 1)
+        self.assertEqual(Zaak.objects.filter(zaakidentificatie='039288072b1c-54f4-485c-8e83-095621e6jk24').count(), 1)
+
+    def test_zaaktype_does_not_exist(self):
+        """
+        See: https://taiga.maykinmedia.nl/project/haarlem-zaakmagazijn/issue/397
+        """
+        org_eenheid = OrganisatorischeEenheidFactory.create(
+            organisatieeenheididentificatie='DVV/KCC')
+
+        zaak_type = ZaakTypeFactory.create(
+            zaaktypeomschrijving='MOR',
+            zaaktypeidentificatie='1',
+            domein='DVV',
+            zaaktypeomschrijving_generiek='Melding Openbare Ruimte',
+            rsin=1,
+            trefwoord=['MOR'],
+            doorlooptijd_behandeling=14,
+            vertrouwelijk_aanduiding='OPENBAAR',
+            publicatie_indicatie='N',
+            zaakcategorie=['Onderhouden','Repareren'],
+            datum_begin_geldigheid_zaaktype='20170901',
+            datum_einde_geldigheid_zaaktype='21000101',
+            organisatorische_eenheid=org_eenheid,
+        )
+
+        vraag = 'creeerZaak_ZakLk01_taiga397.xml'
+        response = self._do_request(self.porttype, vraag)
+
+        self.assertEquals(response.status_code, 200, response.content)
+
+        self.assertEqual(Zaak.objects.all().count(), 1)
+        self.assertEqual(Zaak.objects.filter(zaakidentificatie='2017-0000561').count(), 1)

--- a/src/zaakmagazijn/api/tests/test_faults.py
+++ b/src/zaakmagazijn/api/tests/test_faults.py
@@ -6,6 +6,7 @@ from mock import patch
 from spyne import Fault, InternalError
 from zeep.xsd.const import Nil
 
+from ...rgbz.choices import JaNee
 from ...rgbz.tests.factory_models import StatusFactory
 from ..stuf.choices import (
     BerichtcodeChoices, ClientFoutChoices, ServerFoutChoices
@@ -75,12 +76,24 @@ class StUFFaultTests(BaseSoapTests):
                 scope={
                     'object': zkn_factory['GeefZaakStatus-ZAK-vraagScope'](
                         entiteittype='ZAK',
-                        identificatie=Nil),
+                        identificatie=Nil,
+                        heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagScope'](
+                            entiteittype='ZAKSTT',
+                            indicatieLaatsteStatus=Nil,
+                            datumStatusGezet=Nil,
+                            gerelateerde=zkn_factory['GeefZaakStatus-STT-vraag'](
+                                entiteittype='STT',
+                                volgnummer=Nil,
+                            )
+                        )
+                    ),
                 },
                 gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=zaak_id,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                        indicatieLaatsteStatus=False,
+                        entiteittype='ZAKSTT',
+                        indicatieLaatsteStatus=JaNee.ja,
                     )
                 )
             )

--- a/src/zaakmagazijn/api/tests/test_geef_besluit_details.py
+++ b/src/zaakmagazijn/api/tests/test_geef_besluit_details.py
@@ -10,6 +10,8 @@ from ...rgbz.tests.factory_models import EnkelvoudigInformatieObjectFactory
 
 
 class geefBesluitDetails_BslLv01Tests(BaseSoapTests):
+    antwoord_xpath = '/soap11env:Envelope/soap11env:Body/zds:geefBesluitdetails_BslLa01/zkn:antwoord/zkn:object'
+
     def test_gelijk(self):
         besluit = BesluitFactory.create()
         # Should not show up, because the 'identificatie' field doesn't match.
@@ -37,6 +39,7 @@ class geefBesluitDetails_BslLv01Tests(BaseSoapTests):
                 }),
             },
             gelijk=zkn_factory['geefBesluitDetails-BSL-vraagSelectie'](
+                entiteittype='BSL',  # v
                 identificatie=besluit.identificatie,  # v
             )
         )
@@ -72,13 +75,16 @@ class geefBesluitDetails_BslLv01Tests(BaseSoapTests):
                         'ingangsdatumWerking': Nil,  # v
                         'bst.reactietermijn': Nil,
                         'isUitkomstVan': {
+                            'entiteittype': 'BSLZAK',  # v
                             'gerelateerde': zkn_factory['geefBesluitDetails-ZAK-gerelateerdeVraagScope'](**{
+                                'entiteittype': 'ZAK',  # v
                                 'identificatie': Nil,
                             }),
                         },
                     })
                 },
                 gelijk=zkn_factory['geefBesluitDetails-BSL-vraagSelectie'](
+                    entiteittype='BSL',  # v
                     identificatie=besluit.identificatie,  # v
                 )
             )
@@ -86,10 +92,7 @@ class geefBesluitDetails_BslLv01Tests(BaseSoapTests):
         root = etree.fromstring(response.content)
 
         # The expectation is that only the selected fields are returned.
-        antwoord_obj = root.xpath(
-            '/soap11env:Envelope/soap11env:Body/zds:geefBesluitdetails_BslLa01/zkn:antwoord/zkn:object',
-            namespaces=self.nsmap
-        )[0]
+        antwoord_obj = self._get_body_root(root)
         self._assert_xpath_results(antwoord_obj, 'zkn:identificatie', 1, namespaces=self.nsmap)  # v
         self._assert_xpath_results(antwoord_obj, 'zkn:bst.omschrijving', 0, namespaces=self.nsmap)  # o
         self._assert_xpath_results(antwoord_obj, 'zkn:bst.omschrijvingGeneriek', 0, namespaces=self.nsmap)  # o
@@ -156,6 +159,7 @@ class geefBesluitDetails_BslLa01Tests(BaseSoapTests):
                     })
                 },
                 gelijk=zkn_factory['geefBesluitDetails-BSL-vraagSelectie'](
+                    entiteittype='BSL',  # v
                     identificatie=self.besluit.identificatie,  # v
                 )
             )

--- a/src/zaakmagazijn/api/tests/test_geef_lijst_besluiten.py
+++ b/src/zaakmagazijn/api/tests/test_geef_lijst_besluiten.py
@@ -50,6 +50,7 @@ class geefLijstBesluiten_ZakLv01Tests(BaseSoapTests):
             },
             # http://www.egem.nl/StUF/sector/zkn/0310:GeefLijstBesluiten-ZAK-vraagSelectie
             gelijk=zkn_factory['GeefLijstBesluiten-ZAK-vraagSelectie'](
+                entiteittype='ZAK',  # v
                 identificatie=zaak.zaakidentificatie,
             )
         )
@@ -93,6 +94,7 @@ class geefLijstBesluiten_ZakLv01Tests(BaseSoapTests):
                     )
                 },
                 gelijk=zkn_factory['GeefLijstBesluiten-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=zaak.zaakidentificatie,
                 )
             )
@@ -145,9 +147,23 @@ class geefLijstBesluiten_ZakLv01Tests(BaseSoapTests):
                     indicatorVervolgvraag=False
                 ),
                 scope={
-                    'object': zkn_factory['GeefLijstBesluiten-ZAK-vraagScope'](scope='alles')
+                    'object': zkn_factory['GeefLijstBesluiten-ZAK-vraagScope'](
+                        entiteittype='ZAK',  # v
+                        scope='alles',
+                        leidtTot=zkn_factory['GeefLijstBesluiten-ZAKBSL-vraag'](
+                            entiteittype='ZAKBSL',
+                            gerelateerde=zkn_factory['GeefLijstBesluiten-BSL-gerelateerdeVraag'](
+                                entiteittype='BSL',
+                                # Mandatory elements:
+                                identificatie=Nil,
+                                datumBeslissing=Nil,
+                                ingangsdatumWerking=Nil,
+                            )
+                        )
+                    )
                 },
                 gelijk=zkn_factory['GeefLijstBesluiten-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=zaak.zaakidentificatie,
                 )
             )
@@ -204,6 +220,7 @@ class geefLijstBesluiten_ZakLa01Tests(BaseSoapTests):
                     )
                 },
                 gelijk=zkn_factory['GeefLijstBesluiten-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -336,6 +353,7 @@ class geefLijstBesluiten_Fo02BerichtTests(BaseSoapTests):
                     )
                 },
                 gelijk=zkn_factory['GeefLijstBesluiten-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -350,8 +368,8 @@ class geefLijstBesluiten_Fo02BerichtTests(BaseSoapTests):
             'stuf:stuurgegevens',
             'stuf:stuurgegevens/stuf:berichtcode[text()="Fo02"]',
             'stuf:body',
-            'stuf:body/stuf:code[text()="StUF133"]',
-            'stuf:body/stuf:plek[text()="server"]',
+            'stuf:body/stuf:code[text()="StUF055"]',
+            'stuf:body/stuf:plek[text()="client"]',
         ]
         for expectation in expected_once:
             self._assert_xpath_results(self._get_body_root(root), expectation, 1, namespaces=self.nsmap)

--- a/src/zaakmagazijn/api/tests/test_geef_lijst_zaakdocumenten.py
+++ b/src/zaakmagazijn/api/tests/test_geef_lijst_zaakdocumenten.py
@@ -38,11 +38,12 @@ class geefLijstZaakdocumenten_ZakLv01Tests(BaseSoapTests):
                     identificatie=Nil,
                     # http://www.egem.nl/StUF/sector/zkn/0310:ZAKEDC-basis
                     heeftRelevant=zkn_factory['ZAKEDC-basis'](**{
-                        'entiteittype': 'EDC',
+                        'entiteittype': 'ZAKEDC',
                         'titel': Nil,
                         'beschrijving': Nil,
                         # http://www.egem.nl/StUF/sector/zkn/0310:EDC-basis
                         'gerelateerde': zkn_factory['EDC-basis'](**{
+                            'entiteittype' :'EDC',
                             'identificatie': Nil,
                             'creatiedatum': Nil,
                             'titel': Nil,
@@ -53,6 +54,7 @@ class geefLijstZaakdocumenten_ZakLv01Tests(BaseSoapTests):
             },
             # http://www.egem.nl/StUF/sector/zkn/0310:GeefLijstZaakDocumenten-ZAK-vraagSelectie
             gelijk=zkn_factory['GeefLijstZaakDocumenten-ZAK-vraagSelectie'](
+                entiteittype='ZAK',
                 identificatie=zio.zaak.zaakidentificatie,
             )
         )
@@ -97,6 +99,7 @@ class geefLijstZaakdocumenten_ZakLa01Tests(BaseSoapTests):
                             'titel': Nil,
                             'beschrijving': Nil,
                             'gerelateerde': zkn_factory['EDC-basis'](**{
+                                'entiteittype': 'EDC',
                                 'identificatie': Nil,
                                 'creatiedatum': Nil,
                                 'titel': Nil,
@@ -107,6 +110,7 @@ class geefLijstZaakdocumenten_ZakLa01Tests(BaseSoapTests):
                     )
                 },
                 gelijk=zkn_factory['GeefLijstZaakDocumenten-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=self.zio.zaak.zaakidentificatie,
                 )
             )

--- a/src/zaakmagazijn/api/tests/test_geef_zaak_details.py
+++ b/src/zaakmagazijn/api/tests/test_geef_zaak_details.py
@@ -42,9 +42,13 @@ class GeefZaakdetails_ZakLv01ZAKOBJTests(BaseSoapTests):
                     sortering=1,
                     indicatorVervolgvraag=False),
                 scope={
-                    'object': zkn_factory['ZAK-vraagScope'](scope='alles'),
+                    'object': zkn_factory['ZAK-vraagScope'](
+                        entiteittype='ZAK',  # v
+                        scope='alles'
+                    ),
                 },
                 gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -310,9 +314,13 @@ class geefZaakdetails_ZakLv01Tests(BaseSoapTests):
                 sortering=1,
                 indicatorVervolgvraag=False),
             scope={
-                'object': zkn_factory['ZAK-vraagScope'](scope='alles',),
+                'object': zkn_factory['ZAK-vraagScope'](
+                    entiteittype='ZAK',  # v
+                    scope='alles',
+                ),
             },
             gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                entiteittype='ZAK',  # v
                 identificatie=self.zaak.zaakidentificatie,
             )
         )
@@ -341,11 +349,15 @@ class geefZaakdetails_ZakLv01Tests(BaseSoapTests):
                     entiteittype='ZAK',
                     identificatie=Nil,
                     heeft=zkn_factory['ZAKSTT-vraagScope'](
+                        entiteittype='ZAKSTT',
                         indicatieLaatsteStatus=Nil,
-                        gerelateerde=zkn_factory['STT-vraag']()
+                        gerelateerde=zkn_factory['STT-vraag'](
+                            entiteittype='STT',
+                        )
                     ),),
             },
             gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                entiteittype='ZAK',
                 identificatie=self.zaak.zaakidentificatie,
             )
         )
@@ -371,12 +383,16 @@ class geefZaakdetails_ZakLv01Tests(BaseSoapTests):
                         entiteittype='ZAK',
                         identificatie=Nil,
                         heeft=zkn_factory['ZAKSTT-vraagScope'](
+                            entiteittype='ZAKSTT',
                             indicatieLaatsteStatus=Nil,
-                            gerelateerde=zkn_factory['STT-vraag'](),
+                            gerelateerde=zkn_factory['STT-vraag'](
+                                entiteittype='STT',
+                            ),
                         ),
                     ),
                 },
                 gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -515,6 +531,7 @@ class geefZaakdetails_ZakLa01Tests(BaseSoapTests):
                     }),
                 },
                 gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -543,9 +560,11 @@ class geefZaakdetails_ZakLa01Tests(BaseSoapTests):
                         'entiteittype': 'ZAK',
                         'identificatie': Nil,
                         'heeftBetrekkingOp': zkn_factory['ZAKOBJ-vraagScope'](
+                            entiteittype='ZAKOBJ',  # v
                             gerelateerde=zkn_factory['OBJ-gerelateerdeVraagScope'](
                                 _value_1={
                                     'vestiging': bg_factory['VES-zkn-OBJ-vraag'](
+                                        entiteittype='VES',  # v
                                         vestigingsNummer=Nil,
                                     ),
                                 }
@@ -554,6 +573,7 @@ class geefZaakdetails_ZakLa01Tests(BaseSoapTests):
                     }),
                 },
                 gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -609,9 +629,13 @@ class geefZaakdetails_ZakLa01Tests(BaseSoapTests):
                     sortering=1,
                     indicatorVervolgvraag=False),
                 scope={
-                    'object': zkn_factory['ZAK-vraagScope'](scope='alles'),
+                    'object': zkn_factory['ZAK-vraagScope'](
+                        entiteittype='ZAK',  # v
+                        scope='alles'
+                    ),
                 },
                 gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -794,6 +818,7 @@ class geefZaakdetails_Fo02BerichtTests(BaseSoapTests):
                         identificatie=Nil),
                 },
                 gelijk=zkn_factory['GeefZaakDetails-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',  # v
                     identificatie=self.zaak.zaakidentificatie,
                 )
             )
@@ -807,8 +832,8 @@ class geefZaakdetails_Fo02BerichtTests(BaseSoapTests):
             'stuf:stuurgegevens',
             'stuf:stuurgegevens/stuf:berichtcode[text()="Fo02"]',
             'stuf:body',
-            'stuf:body/stuf:code[text()="StUF133"]',
-            'stuf:body/stuf:plek[text()="server"]',
+            'stuf:body/stuf:code[text()="StUF055"]',
+            'stuf:body/stuf:plek[text()="client"]',
         ]
         for expectation in expected_once:
             self._assert_xpath_results(self._get_body_root(root), expectation, 1, namespaces=self.nsmap)

--- a/src/zaakmagazijn/api/tests/test_geef_zaak_status.py
+++ b/src/zaakmagazijn/api/tests/test_geef_zaak_status.py
@@ -48,23 +48,27 @@ class geefZaakstatus_ZakLv01Tests(BaseSoapTests):
                     entiteittype='ZAK',
                     identificatie=Nil,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagScope'](
+                        entiteittype='ZAKSTT',
                         indicatieLaatsteStatus=Nil,
                         datumStatusGezet=Nil,
                         gerelateerde=zkn_factory['GeefZaakStatus-STT-vraag'](
+                            entiteittype='STT',
                             volgnummer=Nil,
                         )
                     )
                 ),
             },
             gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                entiteittype='ZAK',
                 identificatie=zaak.zaakidentificatie,
                 heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                    indicatieLaatsteStatus=JaNee.nee,
+                    entiteittype='ZAKSTT',
+                    indicatieLaatsteStatus=JaNee.ja,
                 )
             )
         )
         self.assertEquals(len(response.antwoord.object), 1)
-        self.assertEquals(len(response.antwoord.object[0].heeft), 2)
+        self.assertEquals(len(response.antwoord.object[0].heeft), 1)
 
     @skip('TODO [KING]: \'toelichting\' is optional in the scope, but required in '
           'the response. To me, this seems like a bug in the XSD.')
@@ -88,18 +92,22 @@ class geefZaakstatus_ZakLv01Tests(BaseSoapTests):
                         entiteittype='ZAK',
                         identificatie=Nil,
                         heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagScope'](
+                            entiteittype='ZAKSTT',
                             indicatieLaatsteStatus=Nil,
                             datumStatusGezet=Nil,
                             gerelateerde=zkn_factory['GeefZaakStatus-STT-vraag'](
+                                entiteittype='STT',
                                 volgnummer=Nil,
                             )
                         )
                     )
                 },
                 gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=zaak.zaakidentificatie,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                        indicatieLaatsteStatus=JaNee.nee,
+                        entiteittype='ZAKSTT',
+                        indicatieLaatsteStatus=JaNee.ja,
                     )
                 )
             )
@@ -147,9 +155,11 @@ class geefZaakstatus_ZakLv01Tests(BaseSoapTests):
                         identificatie=Nil),
                 },
                 gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=zaak1.zaakidentificatie,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                        indicatieLaatsteStatus=JaNee.nee,
+                        entiteittype='ZAKSTT',
+                        indicatieLaatsteStatus=JaNee.ja,
                     )
                 )
             )
@@ -229,7 +239,7 @@ class geefZaakstatus_ZakLa01Tests(BaseSoapTests):
 
     def setUp(self):
         super().setUp()
-        self.status = StatusFactory.create()
+        self.status = StatusFactory.create(indicatie_laatst_gezette_status=JaNee.ja)
         self.zaak = self.status.zaak
 
     def _do_simple_request(self, raw_response=False):
@@ -252,18 +262,22 @@ class geefZaakstatus_ZakLa01Tests(BaseSoapTests):
                         entiteittype='ZAK',
                         identificatie=Nil,
                         heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagScope'](
+                            entiteittype='ZAKSTT',
                             indicatieLaatsteStatus=Nil,
                             datumStatusGezet=Nil,
                             gerelateerde=zkn_factory['GeefZaakStatus-STT-vraag'](
+                                entiteittype='STT',
                                 volgnummer=Nil,
                             )
                         )
                     ),
                 },
                 gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=self.zaak.zaakidentificatie,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                        indicatieLaatsteStatus=JaNee.nee,
+                        entiteittype='ZAKSTT',
+                        indicatieLaatsteStatus=JaNee.ja,
                     )
                 )
             )
@@ -333,7 +347,7 @@ class geefZaakstatus_Fo02BerichtTests(BaseSoapTests):
     def test_validation_error_message(self):
         client = self._get_client('BeantwoordVraag', strict=False)
 
-        self.status = StatusFactory.create()
+        self.status = StatusFactory.create(indicatie_laatst_gezette_status=JaNee.ja)
         self.zaak = self.status.zaak
 
         #
@@ -378,18 +392,22 @@ class geefZaakstatus_Fo02BerichtTests(BaseSoapTests):
                         entiteittype='ZAK',
                         identificatie=Nil,
                         heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagScope'](
+                            entiteittype='ZAKSTT',
                             indicatieLaatsteStatus=Nil,
                             datumStatusGezet=Nil,
                             gerelateerde=zkn_factory['GeefZaakStatus-STT-vraag'](
+                                entiteittype='STT',
                                 volgnummer=Nil,
                             )
                         )
                     ),
                 },
                 gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=self.zaak.zaakidentificatie,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                        indicatieLaatsteStatus=JaNee.nee,
+                        entiteittype='ZAKSTT',
+                        indicatieLaatsteStatus=JaNee.ja,
                     )
                 )
             )
@@ -398,13 +416,14 @@ class geefZaakstatus_Fo02BerichtTests(BaseSoapTests):
         # These should be part of spyne's testsuite.
         #
         self._assert_xpath_results(root, '/soap11env:Envelope/soap11env:Body/soap11env:Fault/detail', 1, namespaces=self.nsmap)
+        self.pretty_print(root)
 
         expected_once = [
             'stuf:stuurgegevens',
             'stuf:stuurgegevens/stuf:berichtcode[text()="Fo02"]',
             'stuf:body',
-            'stuf:body/stuf:code[text()="StUF133"]',
-            'stuf:body/stuf:plek[text()="server"]',
+            'stuf:body/stuf:code[text()="StUF055"]',
+            'stuf:body/stuf:plek[text()="client"]',
         ]
         for expectation in expected_once:
             self._assert_xpath_results(self._get_body_root(root), expectation, 1, namespaces=self.nsmap)

--- a/src/zaakmagazijn/api/tests/test_geef_zaakdocument_lezen.py
+++ b/src/zaakmagazijn/api/tests/test_geef_zaakdocument_lezen.py
@@ -62,12 +62,15 @@ class geefZaakdocumentLezen_EdcLv01Tests(DMSMockMixin, BaseSoapTests):
             scope={
                 # http://www.egem.nl/StUF/sector/zkn/0310:GeefZaakdocumentLezen-EDC-vraagScope
                 'object': zkn_factory['GeefZaakdocumentLezen-EDC-vraagScope'](**{
+                    'entiteittype': 'EDC',
                     'identificatie': Nil,  # v
                     # http://www.egem.nl/StUF/sector/zkn/0310:GeefZaakdocumentLezen-EDCZAK-vraagScope
                     'isRelevantVoor': zkn_factory['GeefZaakdocumentLezen-EDCZAK-vraagScope'](
+                        entiteittype='EDCZAK',
                         # NOTE: the example WSDL specifies gerelateerdeVraagScope
                         # http://www.egem.nl/StUF/sector/zkn/0310:GeefZaakdocumentLezen-ZAK-gerelateerdeVraagScope
                         gerelateerde=zkn_factory['GeefZaakdocumentLezen-ZAK-gerelateerdeVraagScope'](
+                            entiteittype='ZAK',
                             identificatie=Nil  # v
                         )
                     ),
@@ -90,6 +93,7 @@ class geefZaakdocumentLezen_EdcLv01Tests(DMSMockMixin, BaseSoapTests):
             },
             # http://www.egem.nl/StUF/sector/zkn/0310:GeefZaakdocumentLezen-EDC-vraagSelectie
             gelijk=zkn_factory['GeefZaakdocumentLezen-EDC-vraagSelectie'](
+                entiteittype='EDC',
                 identificatie=edc1.informatieobjectidentificatie,
             )
         )
@@ -130,10 +134,13 @@ class geefZaakdocumentLezen_EdcLa01Tests(DMSMockMixin, BaseSoapTests):
                 ),
                 scope={
                     'object': zkn_factory['GeefZaakdocumentLezen-EDC-vraagScope'](**{
+                        'entiteittype': 'EDC',
                         'identificatie': Nil,  # v
                         'isRelevantVoor': zkn_factory['GeefZaakdocumentLezen-EDCZAK-vraagScope'](
+                            entiteittype='EDCZAK',
                             # NOTE: the example WSDL specifies gerelateerdeVraagScope
                             gerelateerde=zkn_factory['GeefZaakdocumentLezen-ZAK-gerelateerdeVraagScope'](
+                                entiteittype='ZAK',
                                 identificatie=Nil  # v
                             )
                         ),
@@ -155,6 +162,7 @@ class geefZaakdocumentLezen_EdcLa01Tests(DMSMockMixin, BaseSoapTests):
                     })
                 },
                 gelijk=zkn_factory['GeefZaakdocumentLezen-EDC-vraagSelectie'](
+                    entiteittype='EDC',
                     identificatie=self.document.informatieobjectidentificatie,
                 )
             )

--- a/src/zaakmagazijn/api/tests/test_genereer_document_identificatie.py
+++ b/src/zaakmagazijn/api/tests/test_genereer_document_identificatie.py
@@ -20,7 +20,7 @@ class GenereerDocumentIdentificatie_Du02(BaseSoapTests):
                     berichtcode='Di02',
                     referentienummer='123',
                     tijdstipBericht=stuf_datetime.now(),
-                    functie='genereerDocumentIdentificatie'
+                    functie='genereerDocumentidentificatie'
                 )
             )
 

--- a/src/zaakmagazijn/api/tests/test_maak_zaakdocument.py
+++ b/src/zaakmagazijn/api/tests/test_maak_zaakdocument.py
@@ -219,10 +219,8 @@ class maakZaakdocument_EdcLk01Tests(DMSMockMixin, BaseSoapTests):
         document = EnkelvoudigInformatieObject.objects.get()
 
         # the document should have been registered in the DMS
-        self._dms_client.maak_zaakdocument.assert_called_once_with(document, filename='to_be_everywhere.flac')
-
-        # the content should not have been set
-        self._dms_client.zet_inhoud.assert_not_called()
+        self._service_dms_client.maak_zaakdocument.assert_called_once_with(
+            document, filename='to_be_everywhere.flac', sender='john.doe@example.com')
 
         # the document should have been moved to the correct folder
         self._service_dms_client.relateer_aan_zaak.assert_called_once_with(document, zaak)
@@ -314,10 +312,8 @@ class maakZaakdocument_EdcLk01Tests(DMSMockMixin, BaseSoapTests):
         document = EnkelvoudigInformatieObject.objects.get()
 
         # the document should have been registered in the DMS
-        self._dms_client.maak_zaakdocument.assert_called_once_with(document, filename=None)
-
-        # the content should not have been set
-        self._dms_client.zet_inhoud.assert_not_called()
+        self._service_dms_client.maak_zaakdocument.assert_called_once_with(
+            document, filename=None, sender='john.doe@example.com')
 
         # the document should have been moved to the correct folder
         self._service_dms_client.relateer_aan_zaak.assert_called_once_with(document, zaak)
@@ -374,7 +370,8 @@ class STPmaakZaakDocument_EdcLk01Tests(DMSMockMixin, BaseTestPlatformTests):
         )
 
         # the content should not have been set
-        self._dms_client.zet_inhoud.assert_not_called()
+        self._service_dms_client.zet_inhoud.assert_not_called()
+        self._service_dms_client.maak_zaakdocument_met_inhoud.assert_not_called()
 
     def test_maakZaakDocument_EdcLk01_01(self):
         self._dms_client.geef_inhoud.return_value = ('doc 1', BytesIO())
@@ -391,9 +388,8 @@ class STPmaakZaakDocument_EdcLk01Tests(DMSMockMixin, BaseTestPlatformTests):
 
         # assert that a document was created
         zio = ZaakInformatieObject.objects.get()
-        self._dms_client.maak_zaakdocument.assert_called_once_with(
-            zio.informatieobject.enkelvoudiginformatieobject, filename='bestandsnaam'
-        )
+        self._service_dms_client.maak_zaakdocument.assert_called_once_with(
+            zio.informatieobject.enkelvoudiginformatieobject, filename='bestandsnaam', sender='STP')
 
     def test_maakZaakDocument_EdcLk01_03(self):
         self._dms_client.geef_inhoud.return_value = ('doc 1', BytesIO())
@@ -409,10 +405,8 @@ class STPmaakZaakDocument_EdcLk01Tests(DMSMockMixin, BaseTestPlatformTests):
 
         # assert that a document was created, even though <inhoud> is not present
         zio = ZaakInformatieObject.objects.get()
-        self._dms_client.maak_zaakdocument.assert_called_once_with(
-            zio.informatieobject.enkelvoudiginformatieobject, filename=None
-        )
-        self._dms_client.zet_inhoud.assert_not_called()
+        self._service_dms_client.maak_zaakdocument.assert_called_once_with(
+            zio.informatieobject.enkelvoudiginformatieobject, filename=None, sender='STP')
 
     def test_maakZaakDocument_EdcLk01_05(self):
         self._dms_client.geef_inhoud.return_value = ('doc 1', BytesIO())
@@ -429,7 +423,5 @@ class STPmaakZaakDocument_EdcLk01Tests(DMSMockMixin, BaseTestPlatformTests):
 
         # assert that a document was created, even though <inhoud> is not present
         zio = ZaakInformatieObject.objects.get()
-        self._dms_client.maak_zaakdocument.assert_called_once_with(
-            zio.informatieobject.enkelvoudiginformatieobject, filename=None
-        )
-        self._dms_client.zet_inhoud.assert_not_called()
+        self._service_dms_client.maak_zaakdocument.assert_called_once_with(
+            zio.informatieobject.enkelvoudiginformatieobject, filename=None, sender='STP')

--- a/src/zaakmagazijn/api/tests/test_voeg_besluit_toe.py
+++ b/src/zaakmagazijn/api/tests/test_voeg_besluit_toe.py
@@ -51,6 +51,8 @@ class voegBesluitToe_Di01Tests(BaseSoapTests):
             ),
             object=zkn_factory['VoegBesluitToe_object'](
                 besluit=zkn_factory['VoegBesluitToe-BSL-kennisgeving'](**{
+                    'entiteittype': 'BSL',
+                    'verwerkingssoort': 'T',
                     'identificatie': '12345ABC',
                     'bst.omschrijving': bst.besluittypeomschrijving,
                     'datumBeslissing': today,
@@ -59,12 +61,18 @@ class voegBesluitToe_Di01Tests(BaseSoapTests):
                         beginGeldigheid=today,
                     ),
                     'isVastgelegdIn': zkn_factory['VoegBesluitToe-BSLEDC-kennisgeving'](
+                        entiteittype='BSLEDC',
+                        verwerkingssoort='T',
                         gerelateerde=zkn_factory['VoegBesluitToe-EDC-kerngegevensKennisgeving'](
+                            entiteittype='EDC',
+                            verwerkingssoort='I',
                             identificatie=edc.informatieobjectidentificatie
                         )
                     )
                 }),
                 zaak=zkn_factory['VoegBesluitToe_ZAK-kerngegevensKennisgeving'](
+                    entiteittype='ZAK',
+                    verwerkingssoort='I',
                     identificatie=zaak.zaakidentificatie,
                 )
             )

--- a/src/zaakmagazijn/apiauth/tests/test_apiauth.py
+++ b/src/zaakmagazijn/apiauth/tests/test_apiauth.py
@@ -7,6 +7,7 @@ from lxml import etree
 from zeep.xsd.const import Nil
 
 from ...api.tests.base import BaseSoapTests
+from ...rgbz.choices import JaNee
 from ...rgbz.tests.factory_models import StatusFactory
 from ..models import ServiceOperation
 from ..signals import update_service_operations
@@ -25,7 +26,7 @@ class AuthorizationTests(BaseSoapTests):
 
         self.client = self._get_client('BeantwoordVraag', strict=False)
 
-        self.status = StatusFactory.create()
+        self.status = StatusFactory.create(indicatie_laatst_gezette_status=JaNee.ja)
         self.zaak = self.status.zaak
 
     def _simple_request(self, zaak_id=None, zender=None, ontvanger=None):
@@ -61,12 +62,24 @@ class AuthorizationTests(BaseSoapTests):
                 scope={
                     'object': zkn_factory['GeefZaakStatus-ZAK-vraagScope'](
                         entiteittype='ZAK',
-                        identificatie=Nil),
+                        identificatie=Nil,
+                        heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagScope'](
+                            entiteittype='ZAKSTT',
+                            indicatieLaatsteStatus=Nil,
+                            datumStatusGezet=Nil,
+                            gerelateerde=zkn_factory['GeefZaakStatus-STT-vraag'](
+                                entiteittype='STT',
+                                volgnummer=Nil,
+                            )
+                        )
+                    ),
                 },
                 gelijk=zkn_factory['GeefZaakStatus-ZAK-vraagSelectie'](
+                    entiteittype='ZAK',
                     identificatie=zaak_id,
                     heeft=zkn_factory['GeefZaakStatus-ZAKSTT-vraagSelectie'](
-                        indicatieLaatsteStatus=False,
+                        entiteittype='ZAKSTT',
+                        indicatieLaatsteStatus=JaNee.ja,
                     )
                 )
             )

--- a/src/zaakmagazijn/cmis/fields.py
+++ b/src/zaakmagazijn/cmis/fields.py
@@ -16,14 +16,10 @@ class DMSFieldDescriptor:
         }
 
     def __set__(self, instance, inhoud: BinaireInhoud):
-        if inhoud is None:
-            return
-
-        dms_client.maak_zaakdocument(instance, filename=inhoud.bestandsnaam)
-        content = inhoud.to_cmis()
-        # TODO [TECH]: set bestandsnaam/contentType even if no data is present?
-        if content is not None:
-            dms_client.zet_inhoud(instance, content, inhoud.contentType)
+        # We no longer send the contents of a document to the DMS when the
+        # content is set on the ZM object. Instead, this is done in the
+        # service so various meta data from the request can be set as well.
+        pass
 
 
 class DMSField:

--- a/src/zaakmagazijn/cmis/tests/test_cmis_client.py
+++ b/src/zaakmagazijn/cmis/tests/test_cmis_client.py
@@ -61,7 +61,7 @@ class DMSMixin:
                 self.assertEqual(obj.properties[prop], expected_value)
 
 
-@skipIf(on_jenkins() or should_skip_cmis_tests(), "Skipped while there's not Alfresco running on Jenkins")
+@skipIf(on_jenkins() or should_skip_cmis_tests(), "Skipped while there's no Alfresco running on Jenkins")
 class CMISClientTests(DMSMixin, TestCase):
     def test_boomstructuur(self):
         """
@@ -646,7 +646,7 @@ class CMISClientTests(DMSMixin, TestCase):
         self.assertEqual(len(zaak_folder.getChildren()), 0)
 
 
-@skipIf(on_jenkins() or should_skip_cmis_tests(), "Skipped while there's not Alfresco running on Jenkins")
+@skipIf(on_jenkins() or should_skip_cmis_tests(), "Skipped while there's no Alfresco running on Jenkins")
 class EndToEndTests(DMSMixin, TestCase):
     """
     Intended for tests that verify responses from one client method can be

--- a/src/zaakmagazijn/cmis/tests/test_cmis_integration.py
+++ b/src/zaakmagazijn/cmis/tests/test_cmis_integration.py
@@ -33,7 +33,7 @@ def _cmis_stuf_datetime(value):
     )
 
 
-@skipIf(on_jenkins() or should_skip_cmis_tests(), "Skipped while there's not Alfresco running on Jenkins")
+@skipIf(on_jenkins() or should_skip_cmis_tests(), "Skipped while there's no Alfresco running on Jenkins")
 class CMISClientTests(TransactionTestCase):
 
     def setUp(self):

--- a/src/zaakmagazijn/conf/base.py
+++ b/src/zaakmagazijn/conf/base.py
@@ -397,3 +397,6 @@ CMIS_CLIENT_CLASS = 'zaakmagazijn.cmis.client.CMISDMSClient'
 CMIS_CLIENT_URL = 'http://localhost:8080/alfresco/cmisatom'
 CMIS_CLIENT_USER = 'Admin'
 CMIS_CLIENT_USER_PASSWORD = 'admin'
+
+# Use a property to store the sender information
+CMIS_SENDER_PROPERTY = None

--- a/src/zaakmagazijn/rgbz/models/documenten.py
+++ b/src/zaakmagazijn/rgbz/models/documenten.py
@@ -4,9 +4,8 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.db import models
 
-from zaakmagazijn.cmis.fields import DMSField
-
 from ...api.stuf.utils import set_model_value
+from ...cmis.fields import DMSField
 from ...cmis.models import CMISMixin
 from ...utils import stuf_datetime
 from ...utils.fields import StUFDateField


### PR DESCRIPTION
* Fixed issue where the default value for XSD elements were seen as "provided" by the request. This lead to incorrect lookups.
* Restored validation of the incoming requests again. This was accidentally removed to work with the StUF testplatform in 0.9.4. Note that with the introduction of the KING reference WSDL, this validation is much more strict.
* Altered the ``voegZaakdocumentToe`` service to create a document in a single action instead of 2 (create document, add content to document). This deviates from the specification but prevents documents starting at version 1.1. Documents in the DMS now start at version 1.0.
* Added the "stuurgegevens/zender" information to a custom DMS property. This property can be configured with ``CMIS_SENDER_PROPERTY`` and should be a ``string``, or ``None`` if no sender property is present.