### PR TITLE
Paar kleine aanpassingen voor installatie op nieuw systeem

### DIFF
--- a/deployment/alfresco/Vagrantfile
+++ b/deployment/alfresco/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/xenial64"
-  config.vm.network "forwarded_port", guest: 8080, host: 8080
+  config.vm.network "forwarded_port", guest: 8080, host: 8081
   config.vm.provision "shell", path: "setup.sh"
 
   config.vm.provider "virtualbox" do |vb|

--- a/deployment/alfresco/setup_vagrant.sh
+++ b/deployment/alfresco/setup_vagrant.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Some notes from installing VirtualBox on CentOS 7. 
+# based on: https://gist.github.com/paulmaunders/3e2cbe02c07b6393f7ef0781eed9f97b
+# Install dependencies
+yum -y install gcc make patch  dkms qt libgomp
+yum -y install kernel-headers kernel-devel fontforge binutils glibc-headers glibc-devel
+yum -y install "kernel-devel-uname-r == $(uname -r)"
+
+# Install VirtualBox
+cd /etc/yum.repos.d
+wget http://download.virtualbox.org/virtualbox/rpm/rhel/virtualbox.repo
+yum -y install VirtualBox-5.2
+
+# Build the VirtualBox kernel module 
+export KERN_DIR=/usr/src/kernels/$(uname -r)
+export KERN_VER=$(uname -r)
+/sbin/rcvboxdrv setup
+
+# Install Vagrant
+yum -y install https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_x86_64.rpm

--- a/deployment/centos/vars/settings_example.py
+++ b/deployment/centos/vars/settings_example.py
@@ -100,9 +100,10 @@ ZAAKMAGAZIJN_SYSTEEM = {
 }
 # Incremental ID for Zaak IDs
 ZAAKMAGAZIJN_ZAAK_ID_GENERATOR = 'zaakmagazijn.api.utils.create_unique_id'
+ZAAKMAGAZIJN_URL = ''
 
 # DMS backend
-CMIS_CLIENT_URL = 'http://localhost:8080/alfresco/cmisatom'
+CMIS_CLIENT_URL = 'http://localhost:8081/alfresco/cmisatom'
 CMIS_CLIENT_USER = ''
 CMIS_CLIENT_USER_PASSWORD = ''
 CMIS_UPLOAD_TO = 'zaakmagazijn.cmis.utils.upload_to'


### PR DESCRIPTION
- Ik liep er na installatie op een schoon systeem tegenaan dat Tomcat op poort 8080 alle requests afvangt. Heb Alfresco naar poort 8081 gezet en daar ook de verwijzing naar gedaan. Mogelijk zijn er mooiere oplossingen.

- In het de voorbeeld-settings ontbreekt ZAAKMAGAZIJN_URL, hier liep mijn installatie stuk op

- Ik had een scriptje bij elkaar geknipt en geplakt voor het installeren van Vagrant op een nieuw centos 7-systeem, misschien ook handig voor deze repository